### PR TITLE
Added license shield to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Ansible Role: Audio
 
 [![Build Status](https://travis-ci.org/gantsign/ansible-role-audio.svg?branch=master)](https://travis-ci.org/gantsign/ansible-role-audio)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-gantsign.audio-blue.svg)](https://galaxy.ansible.com/gantsign/audio)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible-role-audio/master/LICENSE)
 
 
 Role to enable audio support.


### PR DESCRIPTION
So users can see the type of license at the top of the page.
