### PR TITLE
Changed to standard GantSign travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo: required
 # Require Ubuntu 14.04
 dist: trusty
 
-# Require docker
+# Require Docker
 services:
   - docker
 


### PR DESCRIPTION
Using a standard `travis.yml` makes maintenance easier.