### PR TITLE
Dropped documented support for Ubuntu Wily

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - wily
+        - xenial
   galaxy_tags:
     - alsa
     - audio


### PR DESCRIPTION
It's no longer a supported Ubuntu version.