### PR TITLE
Changed example role to pure YAML syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Example Playbook
 ```yaml
 - hosts: servers
   roles:
-     - { role: gantsign.audio, audio_users: [ 'vagrant' ] }
+    - role: gantsign.audio
+      audio_users:
+        - vagrant
 ```
 
 More Roles From GantSign


### PR DESCRIPTION
Using the hybrid YAML/JSON syntax is potentially confusing to new users as it's not clear whether this peculiar syntax is a requirement or not.