### PR TITLE
Resolved apt module syntax deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,5 @@
 - name: install audio packages
   become: yes
   apt:
-    name: '{{ item }}'
+    name: '{{ audio_packages }}'
     state: present
-  with_items: '{{ audio_packages }}'


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: u'{{ audio_packages }}'`
and remove the loop. This feature will be removed in version 2.11. Deprecation
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```