### PR TITLE
Dropped support for Ubuntu Trusty

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint:
 
 platforms:
   - name: ansible-role-audio-01
-    image: ubuntu:14.04
+    image: ubuntu:16.04
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Trusty (14.04).