### PR TITLE
Configured Travis CI to test on Ubuntu Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ env:
 # Require the standard build environment
 sudo: required
 
-# Require Ubuntu 14.04
-dist: trusty
+# Require Ubuntu 16.04
+dist: xenial
 
 # Require Docker
 services:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint:
 
 platforms:
   - name: ansible-role-audio-01
-    image: ubuntu:14.04
+    image: ubuntu:16.04
 
 provisioner:
   name: ansible

--- a/vars/distribution-release/trusty.yml
+++ b/vars/distribution-release/trusty.yml
@@ -1,9 +1,0 @@
----
-# Packages to install
-audio_packages:
-  - linux-sound-base
-  - alsa-base
-  - alsa-utils
-  - 'linux-image-{{ ansible_kernel }}'
-  - 'linux-image-extra-{{ ansible_kernel }}'
-  - libasound2

--- a/vars/distribution-release/xenial.yml
+++ b/vars/distribution-release/xenial.yml
@@ -4,6 +4,6 @@ audio_packages:
   - linux-sound-base
   - alsa-base
   - alsa-utils
-  - 'linux-image-{{ ansible_kernel }}'
-  - 'linux-image-extra-{{ ansible_kernel }}'
+  - 'linux-modules-{{ ansible_kernel }}'
+  - 'linux-modules-extra-{{ ansible_kernel }}'
   - libasound2


### PR DESCRIPTION
As of the 13th of August 2019 Ubuntu Xenial is the default Linux distribution for Travis CI.